### PR TITLE
Fix asset parsing to support NAI object format from ingest plugin

### DIFF
--- a/steemdb-sync/internal/processor/handlers/helpers.go
+++ b/steemdb-sync/internal/processor/handlers/helpers.go
@@ -59,10 +59,54 @@ func (m *MongoInserter) QueueAccountDirty(ctx context.Context, accountName strin
 	return err
 }
 
-// --- Amount / type conversion helpers (mirrors legacy sync.py) ---
+// --- Asset / amount conversion helpers ---
+//
+// Steem amounts can appear in two formats depending on the data source:
+//
+//  1. String format (from live_sync / RPC / condenser_api):
+//     "1.000 STEEM", "2.500 SBD", "1234.567890 VESTS"
+//
+//  2. NAI object format (from cold_ingest / ingest plugin / C++ fc::variant):
+//     {"nai":"@@000000021", "amount":"833000", "precision":3}
+//
+// The processor must handle both because the operations collection contains
+// a mix of plugin-sourced and rpc-sourced data.
 
-// SplitAmount parses a Steem amount string like "1.000 STEEM" into (value, unit).
-func SplitAmount(s string) (float64, string) {
+// naiToSymbol maps Steem NAI constants to their human-readable symbols.
+// These are fixed on the Steem chain and never change.
+// Reference: https://developers.steem.io/apiref/transactions.html#_amount_format
+var naiToSymbol = map[string]string{
+	"@@000000021": "STEEM", // precision 3
+	"@@000000013": "SBD",   // precision 3
+	"@@000000037": "VESTS", // precision 6
+}
+
+// ParseAsset parses an amount field that may be a string or NAI object.
+// Returns (value, symbol). On any parse failure returns (0, "").
+//
+// Examples:
+//   "1.000 STEEM"                          → (1.0, "STEEM")
+//   {"nai":"@@000000021","amount":"833000","precision":3} → (833.0, "STEEM")
+func ParseAsset(v interface{}) (float64, string) {
+	if v == nil {
+		return 0, ""
+	}
+
+	// Try string format: "1.000 STEEM"
+	if s, ok := v.(string); ok {
+		return parseStringAsset(s)
+	}
+
+	// Try NAI object format: map[string]interface{}
+	if m, ok := v.(map[string]interface{}); ok {
+		return parseNAIAsset(m)
+	}
+
+	return 0, ""
+}
+
+// parseStringAsset handles "1.000 STEEM" format.
+func parseStringAsset(s string) (float64, string) {
 	parts := strings.Fields(s)
 	if len(parts) < 2 {
 		return 0, ""
@@ -74,16 +118,61 @@ func SplitAmount(s string) (float64, string) {
 	return val, parts[1]
 }
 
-// AmountValue extracts just the numeric part of an amount string.
-func AmountValue(s string) float64 {
-	v, _ := SplitAmount(s)
-	return v
+// parseNAIAsset handles {"nai":"@@000000021","amount":"833000","precision":3} format.
+func parseNAIAsset(m map[string]interface{}) (float64, string) {
+	// Get raw integer amount (e.g. "833000")
+	amountStr := ""
+	if v, ok := m["amount"]; ok {
+		if s, ok := v.(string); ok {
+			amountStr = s
+		}
+	}
+
+	// Get precision to divide the integer (e.g. precision 3 → divide by 1000)
+	precision := 0
+	if v, ok := m["precision"]; ok {
+		switch p := v.(type) {
+		case float64:
+			precision = int(p)
+		case int:
+			precision = p
+		case int64:
+			precision = int(p)
+		}
+	}
+
+	// Get symbol from NAI lookup
+	symbol := ""
+	if v, ok := m["nai"]; ok {
+		if nai, ok := v.(string); ok {
+			symbol = naiToSymbol[nai]
+		}
+	}
+
+	// Parse the integer amount
+	rawVal, err := strconv.ParseFloat(amountStr, 64)
+	if err != nil {
+		return 0, symbol
+	}
+
+	// Apply precision divisor
+	divisor := 1.0
+	for i := 0; i < precision; i++ {
+		divisor *= 10
+	}
+	return rawVal / divisor, symbol
 }
 
-// AmountUnit extracts just the unit part of an amount string.
-func AmountUnit(s string) string {
-	_, unit := SplitAmount(s)
-	return unit
+// AssetValue extracts just the numeric value from an amount field (any format).
+func AssetValue(v interface{}) float64 {
+	val, _ := ParseAsset(v)
+	return val
+}
+
+// AssetSymbol extracts just the symbol/unit from an amount field (any format).
+func AssetSymbol(v interface{}) string {
+	_, sym := ParseAsset(v)
+	return sym
 }
 
 // GetString reads a string field from a map, returning "" if missing or wrong type.
@@ -94,4 +183,12 @@ func GetString(m map[string]interface{}, key string) string {
 		}
 	}
 	return ""
+}
+
+// GetField reads any field from a map, returning nil if missing.
+func GetField(m map[string]interface{}, key string) interface{} {
+	if v, ok := m[key]; ok {
+		return v
+	}
+	return nil
 }

--- a/steemdb-sync/internal/processor/handlers/helpers_test.go
+++ b/steemdb-sync/internal/processor/handlers/helpers_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 )
 
-func TestSplitAmount(t *testing.T) {
+func TestParseAsset_StringFormat(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		wantVal  float64
-		wantUnit string
+		name    string
+		input   string
+		wantVal float64
+		wantSym string
 	}{
 		{"STEEM amount", "1.000 STEEM", 1.0, "STEEM"},
 		{"SBD amount", "2.500 SBD", 2.5, "SBD"},
@@ -24,48 +24,108 @@ func TestSplitAmount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotVal, gotUnit := SplitAmount(tt.input)
+			gotVal, gotSym := ParseAsset(tt.input)
 			if gotVal != tt.wantVal {
-				t.Errorf("SplitAmount(%q) value = %v, want %v", tt.input, gotVal, tt.wantVal)
+				t.Errorf("ParseAsset(%q) value = %v, want %v", tt.input, gotVal, tt.wantVal)
 			}
-			if gotUnit != tt.wantUnit {
-				t.Errorf("SplitAmount(%q) unit = %q, want %q", tt.input, gotUnit, tt.wantUnit)
+			if gotSym != tt.wantSym {
+				t.Errorf("ParseAsset(%q) symbol = %q, want %q", tt.input, gotSym, tt.wantSym)
 			}
 		})
 	}
 }
 
-func TestAmountValue(t *testing.T) {
+func TestParseAsset_NAIFormat(t *testing.T) {
 	tests := []struct {
-		input string
-		want  float64
+		name    string
+		input   map[string]interface{}
+		wantVal float64
+		wantSym string
 	}{
-		{"1.000 STEEM", 1.0},
-		{"99.999 SBD", 99.999},
-		{"", 0},
+		{
+			"STEEM NAI",
+			map[string]interface{}{"nai": "@@000000021", "amount": "833000", "precision": float64(3)},
+			833.0, "STEEM",
+		},
+		{
+			"SBD NAI",
+			map[string]interface{}{"nai": "@@000000013", "amount": "2500000", "precision": float64(3)},
+			2500.0, "SBD",
+		},
+		{
+			"VESTS NAI",
+			map[string]interface{}{"nai": "@@000000037", "amount": "1234567890", "precision": float64(6)},
+			1234.567890, "VESTS",
+		},
+		{
+			"zero STEEM NAI",
+			map[string]interface{}{"nai": "@@000000021", "amount": "0", "precision": float64(3)},
+			0.0, "STEEM",
+		},
+		{
+			"unknown NAI",
+			map[string]interface{}{"nai": "@@999999999", "amount": "1000", "precision": float64(3)},
+			1.0, "", // value parsed, symbol unknown
+		},
+		{
+			"missing amount",
+			map[string]interface{}{"nai": "@@000000021", "precision": float64(3)},
+			0.0, "STEEM",
+		},
 	}
+
 	for _, tt := range tests {
-		got := AmountValue(tt.input)
-		if got != tt.want {
-			t.Errorf("AmountValue(%q) = %v, want %v", tt.input, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			gotVal, gotSym := ParseAsset(tt.input)
+			if gotVal != tt.wantVal {
+				t.Errorf("ParseAsset(NAI) value = %v, want %v", gotVal, tt.wantVal)
+			}
+			if gotSym != tt.wantSym {
+				t.Errorf("ParseAsset(NAI) symbol = %q, want %q", gotSym, tt.wantSym)
+			}
+		})
 	}
 }
 
-func TestAmountUnit(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"1.000 STEEM", "STEEM"},
-		{"99.999 SBD", "SBD"},
-		{"", ""},
+func TestParseAsset_NilAndInvalid(t *testing.T) {
+	// nil
+	val, sym := ParseAsset(nil)
+	if val != 0 || sym != "" {
+		t.Errorf("ParseAsset(nil) = (%v, %q), want (0, \"\")", val, sym)
 	}
-	for _, tt := range tests {
-		got := AmountUnit(tt.input)
-		if got != tt.want {
-			t.Errorf("AmountUnit(%q) = %q, want %q", tt.input, got, tt.want)
-		}
+
+	// invalid type (int)
+	val, sym = ParseAsset(42)
+	if val != 0 || sym != "" {
+		t.Errorf("ParseAsset(42) = (%v, %q), want (0, \"\")", val, sym)
+	}
+}
+
+func TestAssetValue(t *testing.T) {
+	// String format
+	if v := AssetValue("1.000 STEEM"); v != 1.0 {
+		t.Errorf("AssetValue(string) = %v, want 1.0", v)
+	}
+	// NAI format
+	nai := map[string]interface{}{"nai": "@@000000021", "amount": "833000", "precision": float64(3)}
+	if v := AssetValue(nai); v != 833.0 {
+		t.Errorf("AssetValue(NAI) = %v, want 833.0", v)
+	}
+	// nil
+	if v := AssetValue(nil); v != 0 {
+		t.Errorf("AssetValue(nil) = %v, want 0", v)
+	}
+}
+
+func TestAssetSymbol(t *testing.T) {
+	// String format
+	if s := AssetSymbol("1.000 STEEM"); s != "STEEM" {
+		t.Errorf("AssetSymbol(string) = %q, want STEEM", s)
+	}
+	// NAI format
+	nai := map[string]interface{}{"nai": "@@000000013", "amount": "100", "precision": float64(3)}
+	if s := AssetSymbol(nai); s != "SBD" {
+		t.Errorf("AssetSymbol(NAI) = %q, want SBD", s)
 	}
 }
 
@@ -90,5 +150,18 @@ func TestGetString(t *testing.T) {
 				t.Errorf("GetString(%v, %q) = %q, want %q", tt.m, tt.key, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetField(t *testing.T) {
+	m := map[string]interface{}{"name": "alice", "amount": map[string]interface{}{"nai": "@@000000021"}}
+	if v := GetField(m, "name"); v != "alice" {
+		t.Errorf("GetField(name) = %v, want alice", v)
+	}
+	if v := GetField(m, "amount"); v == nil {
+		t.Error("GetField(amount) should not be nil")
+	}
+	if v := GetField(m, "missing"); v != nil {
+		t.Errorf("GetField(missing) = %v, want nil", v)
 	}
 }

--- a/steemdb-sync/internal/processor/handlers/rewards.go
+++ b/steemdb-sync/internal/processor/handlers/rewards.go
@@ -30,9 +30,8 @@ func (h *CurationRewardHandler) Handle(ctx context.Context, op *model.Operation,
 	curator := GetString(v, "curator")
 	commentAuthor := GetString(v, "comment_author")
 	commentPermlink := GetString(v, "comment_permlink")
-	rewardStr := GetString(v, "reward")
 
-	rewardVal := AmountValue(rewardStr)
+	rewardVal := AssetValue(GetField(v, "reward"))
 
 	id := fmt.Sprintf("%d/%s/%s/%s", op.BlockNum, curator, commentAuthor, commentPermlink)
 
@@ -89,9 +88,9 @@ func (h *AuthorRewardHandler) Handle(ctx context.Context, op *model.Operation, b
 	author := GetString(v, "author")
 	permlink := GetString(v, "permlink")
 
-	sbdPayout := AmountValue(GetString(v, "sbd_payout"))
-	steemPayout := AmountValue(GetString(v, "steem_payout"))
-	vestingPayout := AmountValue(GetString(v, "vesting_payout"))
+	sbdPayout := AssetValue(GetField(v, "sbd_payout"))
+	steemPayout := AssetValue(GetField(v, "steem_payout"))
+	vestingPayout := AssetValue(GetField(v, "vesting_payout"))
 
 	id := fmt.Sprintf("%d/%s/%s", op.BlockNum, author, permlink)
 

--- a/steemdb-sync/internal/processor/handlers/transfer.go
+++ b/steemdb-sync/internal/processor/handlers/transfer.go
@@ -27,9 +27,8 @@ func (h *TransferHandler) Handle(ctx context.Context, op *model.Operation, block
 	v := op.OpValue
 	from := GetString(v, "from")
 	to := GetString(v, "to")
-	amountStr := GetString(v, "amount")
 
-	amountVal, amountType := SplitAmount(amountStr)
+	amountVal, amountType := ParseAsset(GetField(v, "amount"))
 
 	id := fmt.Sprintf("%d/%s/%s", op.BlockNum, from, to)
 

--- a/steemdb-sync/test/docker-compose/Dockerfile.cold-ingest
+++ b/steemdb-sync/test/docker-compose/Dockerfile.cold-ingest
@@ -19,6 +19,9 @@ COPY configs/ ./configs/
 # Build cold_ingest binary
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cold_ingest ./cmd/cold_ingest
 
+# Build processor binary
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o processor ./cmd/processor
+
 # Final stage
 FROM alpine:latest
 
@@ -32,8 +35,9 @@ RUN addgroup -g 1000 appuser && \
 # Set working directory
 WORKDIR /app
 
-# Copy binary from builder
+# Copy binaries from builder
 COPY --from=builder /build/cold_ingest /app/cold_ingest
+COPY --from=builder /build/processor /app/processor
 
 # Create directories
 RUN mkdir -p /app/configs /app/logs /app/data && \

--- a/steemdb-sync/test/docker-compose/docker-compose.yml
+++ b/steemdb-sync/test/docker-compose/docker-compose.yml
@@ -55,6 +55,28 @@ services:
       start_period: 10s
     restart: unless-stopped
 
+  # Processor Service (consumes operations → derived collections)
+  processor:
+    build:
+      context: ../..
+      dockerfile: test/docker-compose/Dockerfile.cold-ingest
+    container_name: cold-ingest-processor
+    ports:
+      - "9092:9092"
+    environment:
+      - CONFIG_PATH=/app/configs/config.yaml
+      - MONGO_URI=mongodb://${MONGO_USERNAME:-admin}:${MONGO_PASSWORD:-123456}@mongo:27017/${MONGO_DATABASE:-steemdb_test}?authSource=admin
+    volumes:
+      - ./configs:/app/configs:ro
+      - ./logs:/app/logs
+    networks:
+      - cold-ingest-network
+    depends_on:
+      mongo:
+        condition: service_healthy
+    command: ["/app/processor", "-config", "/app/configs/config.yaml"]
+    restart: unless-stopped
+
   # Steemd Node with Ingest Plugin
   steemd:
     image: ${STEEMD_IMAGE:-steemd:with-ingest}

--- a/steemdb-sync/test/docker-compose/steemd-entrypoint.sh
+++ b/steemdb-sync/test/docker-compose/steemd-entrypoint.sh
@@ -15,6 +15,7 @@ CMD=(
     --ingest-batch-size "${INGEST_BATCH_SIZE:-100}"
     --ingest-batch-timeout "${INGEST_BATCH_TIMEOUT:-1000}"
     --data-dir "${DATA_DIR:-/var/steem}"
+    --p2p-seed-node ""
 )
 
 # Add --stop-replay-at-block if STOP_REPLAY_AT_BLOCK is set and not 0


### PR DESCRIPTION
## Summary

Fixes a data format mismatch that caused all amount fields (transfer, reward, payout) to be stored as `0` with empty symbol.

## Problem

The `operations` collection contains amounts in **two different formats** depending on the data source:

| Source | Format | Example |
|--------|--------|---------|
| `cold_ingest` (ingest plugin / C++ fc::variant) | **NAI object** | `{"nai":"@@000000021","amount":"833000","precision":3}` |
| `live_sync` (RPC / condenser_api) | **String** | `"1.000 STEEM"` |

The original `SplitAmount()` only handled string format, so all NAI-format amounts were silently parsed as `0`.

## Fix

- Add `ParseAsset(interface{})` that auto-detects format (string vs NAI map) and converts both to `(float64, symbol)`
- NAI → symbol mapping: `@@000000021`=STEEM, `@@000000013`=SBD, `@@000000037`=VESTS
- Update `transfer`, `curation_reward`, `author_reward` handlers to use `ParseAsset` / `AssetValue`
- Add `GetField()` helper (returns `interface{}`, unlike `GetString` which only handles strings)

## Test environment improvements (included)

- Add `processor` service to `test/docker-compose/docker-compose.yml`
- Build `processor` binary alongside `cold_ingest` in `Dockerfile.cold-ingest`
- Add `--p2p-seed-node ""` to steemd entrypoint (prevents port 1776 conflict in replay-only mode)

## Testing

- 18 unit tests passing (9 ParseAsset string/NAI/edge cases + 9 existing dispatcher/helper tests)
- Verified end-to-end with `steemd --replay` → `cold_ingest` → `processor` pipeline:

```
Before: transfer amount=0, type=""
After:  transfer amount=833, type=STEEM
```

NAI input `{"nai":"@@000000021","amount":"833000","precision":3}` → correctly parsed as `833.0 STEEM`.